### PR TITLE
Set overflow in Sidebar.vue, MapBar.vue and PageRenderer.vue to "auto"

### DIFF
--- a/src/components/map/MapBar.vue
+++ b/src/components/map/MapBar.vue
@@ -83,7 +83,7 @@ defineEmits(['ribbonClicked', 'tabToggled', 'allTabsToggled'])
   flex-direction: column;
   align-items: center;
   justify-content: stretch;
-  overflow: scroll;
+  overflow: auto;
   gap: 2px;
 }
 

--- a/src/components/sidebar/SideBar.vue
+++ b/src/components/sidebar/SideBar.vue
@@ -119,7 +119,7 @@ function badToTheBoneEffect() {
 }
 
 .SideBar > div:first-of-type {
-  overflow: scroll;
+  overflow: auto;
 }
 
 .revertHide {

--- a/src/views/PageRenderer.vue
+++ b/src/views/PageRenderer.vue
@@ -47,7 +47,7 @@ setTimeout(() => scrollToId(route.hash.slice(1)), 250)
   flex-direction: column;
   justify-content: stretch;
   align-items: center;
-  overflow: scroll;
+  overflow: auto;
   gap: 16px;
   background: url('/Images/Home.png') no-repeat center center;
   background-size: cover;


### PR DESCRIPTION
In chromium based browsers, overflow being set to "scroll" makes the scroll bar always visible as seen here:
![ScrollbarIssue](https://github.com/imalonelynerd/VOTV-Secrets-Website/assets/96014698/89385e6f-d638-444d-aa97-fbe64a087a3e)
![ScrollbarIssueMap](https://github.com/imalonelynerd/VOTV-Secrets-Website/assets/96014698/f00c8eb0-4076-49b6-a110-89d06a8069cf)
Setting overflow to "auto" fixes this issue and still retains the scroll bar when required resulting in a much cleaner looking page on chromium based browsers.